### PR TITLE
Make sure unicode characters are allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Code to run a remote game of Hat.
 ## Testing
 
 This project uses Vagrant. To test the application locally, `vagrant up` and it is running at [http://localhost:8080/hat](http://localhost:8080/hat). To run the tests, ssh to the box and `python3 /vagrant/remotehat/manage.py test hat`
+
+## Deploying
+
+At the moment, set up of the remote server is manual, and deployment only deploys the code under `/remote/hat` to the same place on the server. That means the database and the apache server all need to be set up prior to first deploy.

--- a/remotehat/hat/tests.py
+++ b/remotehat/hat/tests.py
@@ -21,6 +21,13 @@ class ViewTests(TestCase):
         testFamousName = FamousNames.objects.get().name_text
         self.assertEqual(testFamousName, "Maya Angelou")
 
+    def test_submit_unicode_name(self):
+        c = Client()
+        response = c.post(reverse('hat:submit_name'), {'famous_name': 'Karol Józef Wojtyła'})
+        self.assertEqual(response.status_code, 200)
+        testFamousName = FamousNames.objects.get().name_text
+        self.assertEqual(testFamousName, "Karol Józef Wojtyła")
+
     def test_submit_blank_name_doesnt_save(self):
         c = Client()
         response = c.post(reverse('hat:submit_name'), {'famous_name': ''})

--- a/remotehat/remotehat/settings.py
+++ b/remotehat/remotehat/settings.py
@@ -74,6 +74,10 @@ DATABASES = {
         'PASSWORD': os.environ.get('DB_PASSWORD', 'password'),
         'HOST': os.environ.get('DB_HOST', '127.0.0.1'),
         'PORT': os.environ.get('DB_PORT', '3306'),
+        'TEST': {
+            'CHARSET': 'utf8',
+            'COLLATION': 'utf8_general_ci',
+        },
     }
 }
 


### PR DESCRIPTION
When we played last, one of the players discovered that unicode characters caused an error, e.g. Karol Józef Wojtyła.

This did not work on the server but worked locally.

This was because the local server (but not the test database) were set up to support a UTF-8 character set, but the remote server was not.

This pull request fixes the test database set up, and adds a test so we can keep an eye on whether this continues to work.

Because the server is currently set up manually, I had to fix that manually, which I did using the following commands:

```
ALTER DATABASE hat CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE hat_famousnames CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
```